### PR TITLE
UF2 loader compatibility, SD cart config storage, help command added

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1460,6 +1460,7 @@ dependencies = [
  "async-trait",
  "bitflags 2.9.0",
  "chrono",
+ "cortex-m",
  "cortex-m-rt",
  "crc",
  "critical-section",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ wezterm-cell = { git="https://github.com/wezterm/wezterm", default-features=fals
 wezterm-char-props = { git="https://github.com/wezterm/wezterm", default-features=false }
 wezterm-escape-parser = { git="https://github.com/wezterm/wezterm" }
 wezterm-surface = { git="https://github.com/wezterm/wezterm" }
+cortex-m = "0.7.7"
 
 [profile.dev]
 debug = 2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 default = []
 pimoroni2w = ["rp235xb"]
 pico2w = ["rp235xa"]
+configsdcard = []
 rp235xb = ["embassy-rp/rp235xb"]
 rp235xa = ["embassy-rp/rp235xa"]
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-CHIP=pimoroni2w
+CHIP=pico2w
+#pimoroni2w
 
 check:
 	cargo +nightly check --features $(CHIP)

--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,27 @@
 CHIP=pico2w
 #pimoroni2w
 
-check:
-	cargo +nightly check --features $(CHIP)
+#FEATURES=${CHIP},configsdcard
+FEATURES=${CHIP}
 
+
+check:
+	cargo +nightly check --features $(FEATURES)
 clean:
 	cargo clean
 	rm *.uf2
 
 image:
-	PATH=$(PWD)/picotool/build:${PATH} RUST_LOG=info RUSTC_LOG=rustc_codegen_ssa::back::link=info cargo +nightly build --release --features $(CHIP)
-	PATH=$(PWD)/picotool/build:${PATH} picotool uf2 convert -t elf target/thumbv8m.main-none-eabihf/release/picocalc-wezterm wezterm-$(CHIP)-`git -c core.abbrev=8 show -s --format=%cd-%h --date=format:%Y%m%d`.uf2
+	PATH="$(PWD)/picotool/build:${PATH}" RUST_LOG=info RUSTC_LOG=rustc_codegen_ssa::back::link=info cargo +nightly build --release --features $(FEATURES)
+	PATH="$(PWD)/picotool/build:${PATH}" picotool uf2 convert -t elf target/thumbv8m.main-none-eabihf/release/picocalc-wezterm wezterm-$(CHIP)-`git -c core.abbrev=8 show -s --format=%cd-%h --date=format:%Y%m%d`.uf2
 
 flash-ocd: image
-	PATH=$(PWD)/picotool/build:${PATH} RUST_LOG=info RUSTC_LOG=rustc_codegen_ssa::back::link=info cargo +nightly build --release --features $(CHIP)
+	PATH="$(PWD)/picotool/build:${PATH}" RUST_LOG=info RUSTC_LOG=rustc_codegen_ssa::back::link=info cargo +nightly build --release --features $(FEATURES)
 	openocd -f interface/cmsis-dap.cfg -f target/rp2350.cfg -c "adapter speed 5000" -c "program target/thumbv8m.main-none-eabihf/release/picocalc-wezterm verify reset exit"
 
 flash:
-	PATH=$(PWD)/picotool/build:${PATH} RUST_LOG=info RUSTC_LOG=rustc_codegen_ssa::back::link=info cargo +nightly run --release --features $(CHIP)
-	#PATH=$(PWD)/picotool/build:${PATH} cargo +nightly run --release
+	PATH="$(PWD)/picotool/build:${PATH}" RUST_LOG=info RUSTC_LOG=rustc_codegen_ssa::back::link=info cargo +nightly run --release --features $(FEATURES)
+	#PATH="$(PWD)/picotool/build:${PATH}" cargo +nightly run --release
 
 fmt:
 	cargo +nightly fmt

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 CHIP=pico2w
 #pimoroni2w
 
-#FEATURES=${CHIP},configsdcard
-FEATURES=${CHIP}
+FEATURES=${CHIP},configsdcard
+#FEATURES=${CHIP}
 
 
 check:

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This project is a bit of a toy, but it's a fun one to hack on!
  * Terminal Emulation
     * many escape sequences currently not implemented
     * keyboard encoding not yet fully implemented
+ * [x] Works with uf2loader by @pelrun - just put its uf2 file in /pico2-apps of an SD card
 
 ## Using it
 
@@ -34,7 +35,7 @@ $ reboot
 
 > [!CAUTION]
 > Please note that the config storage is clear-text data held
-> in a region of the flash memory on the device. If someone
+> in a file called WEZTERM.CFG on the SD card. If someone
 > has your device, it is possible to extract any credentials
 > from it simply by booting it up and running `config list`.
 
@@ -60,7 +61,7 @@ $ config set ssh_pw AndPassWord
 
 > [!CAUTION]
 > Please note that the config storage is clear-text data held
-> in a region of the flash memory on the device. If someone
+> in a text file on the device SD card. If someone
 > has your device, it is possible to extract any credentials
 > from it simply by booting it up and running `config list`.
 
@@ -102,7 +103,7 @@ Operates on the config section of flash storage. This is 8KiB in size.
 
 > [!CAUTION]
 > Please note that the config storage is clear-text data held
-> in a region of the flash memory on the device. If someone
+> in a text file on the device SD card. If someone
 > has your device, it is possible to extract any credentials
 > from it simply by booting it up and running `config list`.
 

--- a/src/config_sdcard.rs
+++ b/src/config_sdcard.rs
@@ -19,7 +19,7 @@ pub static CONFIG: LazyLock<Mutex<CriticalSectionRawMutex, Configuration>> =
 pub struct Configuration {
     cache: FnvIndexMap<StrKey, StrValue, 32>,
     dirty: bool,
-    loaded: bool, // Gibt an, ob erfolgreich von SD-Karte geladen wurde
+    loaded: bool,
 }
 
 pub type StrKey = FixedString<32>;
@@ -40,7 +40,6 @@ impl From<embedded_sdmmc::Error<embedded_sdmmc::SdCardError>> for ConfigError {
 }
 
 impl Configuration {
-    /// Lädt die Konfiguration von der SD-Karte
     async fn load_from_sd(&mut self) -> Result<(), ConfigError> {
         let mut storage = STORAGE.get().lock().await;
         let Some(mgr) = storage.vol_mgr() else {
@@ -50,13 +49,11 @@ impl Configuration {
         let mut vol = mgr.open_volume(VolumeIdx(0))?;
         let mut root_dir = vol.open_root_dir()?;
 
-        // Öffne Datei und lese sie komplett, bevor wir root_dir schließen
         let buffer_result: Result<Vec<u8>, ConfigError> = {
             match root_dir.open_file_in_dir(CONFIG_FILENAME, embedded_sdmmc::Mode::ReadOnly) {
                 Ok(mut file) => {
                     let mut buffer = Vec::new();
 
-                    // Lese die Datei in Chunks
                     loop {
                         let mut chunk = [0u8; 512];
                         match file.read(&mut chunk) {
@@ -72,18 +69,13 @@ impl Configuration {
                     file.close()?;
                     Ok(buffer)
                 }
-                Err(embedded_sdmmc::Error::NotFound) => {
-                    // Datei existiert noch nicht, ist ok
-                    Ok(Vec::new())
-                }
+                Err(embedded_sdmmc::Error::NotFound) => Ok(Vec::new()),
                 Err(e) => Err(e.into()),
             }
         };
 
-        // Jetzt können wir root_dir sicher schließen
         root_dir.close()?;
 
-        // Verarbeite das Ergebnis
         match buffer_result {
             Ok(buffer) => {
                 if buffer.is_empty() {
@@ -93,7 +85,6 @@ impl Configuration {
                     return Ok(());
                 }
 
-                // Parse die Konfigurationsdatei (Format: KEY=VALUE pro Zeile)
                 self.cache.clear();
                 let content = String::from_utf8_lossy(&buffer);
                 for line in content.lines() {
@@ -112,7 +103,6 @@ impl Configuration {
         }
     }
 
-    /// Speichert die Konfiguration auf der SD-Karte
     async fn save_to_sd(&mut self) -> Result<(), ConfigError> {
         if !self.dirty {
             return Ok(());
@@ -126,7 +116,6 @@ impl Configuration {
         let mut vol = mgr.open_volume(VolumeIdx(0))?;
         let mut root_dir = vol.open_root_dir()?;
 
-        // Erstelle den Dateiinhalt
         let mut content = String::new();
         for (key, value) in &self.cache {
             content.push_str(key.as_str());
@@ -137,17 +126,14 @@ impl Configuration {
 
         let data = content.as_bytes();
 
-        // Lösche alte Datei falls vorhanden
         let _ = root_dir.delete_file_in_dir(CONFIG_FILENAME);
 
-        // Öffne, schreibe und schließe die Datei, bevor wir root_dir schließen
         let write_result: Result<(), ConfigError> = {
             match root_dir.open_file_in_dir(
                 CONFIG_FILENAME,
                 embedded_sdmmc::Mode::ReadWriteCreateOrTruncate,
             ) {
                 Ok(mut file) => {
-                    // Schreibe die Daten
                     let result = match file.write(data) {
                         Ok(_) => Ok(()),
                         Err(e) => Err(e.into()),
@@ -159,10 +145,8 @@ impl Configuration {
             }
         };
 
-        // Jetzt können wir root_dir sicher schließen
         root_dir.close()?;
 
-        // Wenn erfolgreich, setze dirty auf false
         if write_result.is_ok() {
             self.dirty = false;
         }
@@ -171,7 +155,6 @@ impl Configuration {
     }
 
     pub async fn fetch(&mut self, key: &str) -> Result<Option<StrValue>, ConfigError> {
-        // Lade erst die Konfiguration, falls noch nicht geladen
         if !self.loaded {
             let _ = self.load_from_sd().await;
         }
@@ -181,7 +164,6 @@ impl Configuration {
     }
 
     pub async fn remove(&mut self, key: &str) -> Result<(), ConfigError> {
-        // Lade erst die Konfiguration, falls noch nicht geladen
         if !self.loaded {
             let _ = self.load_from_sd().await;
         }
@@ -195,7 +177,6 @@ impl Configuration {
     }
 
     pub async fn store(&mut self, key: &str, value: StrValue) -> Result<(), ConfigError> {
-        // Lade erst die Konfiguration, falls noch nicht geladen
         if !self.loaded {
             let _ = self.load_from_sd().await;
         }
@@ -210,12 +191,11 @@ impl Configuration {
     pub async fn format(&mut self) -> Result<(), ConfigError> {
         self.cache.clear();
         self.dirty = true;
-        self.loaded = true; // Nach format ist die Config geladen (wenn auch leer)
+        self.loaded = true;
         self.save_to_sd().await
     }
 
     pub async fn get_all(&mut self) -> Result<FnvIndexMap<StrKey, StrValue, 32>, ConfigError> {
-        // Lade erst die Konfiguration, falls noch nicht geladen
         if !self.loaded {
             let _ = self.load_from_sd().await;
         }

--- a/src/config_sdcard.rs
+++ b/src/config_sdcard.rs
@@ -1,0 +1,279 @@
+use crate::fixed_str::FixedString;
+use crate::storage::STORAGE;
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_sync::lazy_lock::LazyLock;
+use embassy_sync::mutex::Mutex;
+use embedded_sdmmc::VolumeIdx;
+use heapless::FnvIndexMap;
+
+extern crate alloc;
+use alloc::string::String;
+use alloc::vec::Vec;
+
+const CONFIG_FILENAME: &str = "WEZTERM.CFG";
+
+pub static CONFIG: LazyLock<Mutex<CriticalSectionRawMutex, Configuration>> =
+    LazyLock::new(|| Mutex::new(Configuration::default()));
+
+#[derive(Debug, Default)]
+pub struct Configuration {
+    cache: FnvIndexMap<StrKey, StrValue, 32>,
+    dirty: bool,
+    loaded: bool, // Gibt an, ob erfolgreich von SD-Karte geladen wurde
+}
+
+pub type StrKey = FixedString<32>;
+pub type StrValue = FixedString<128>;
+
+#[derive(Debug)]
+pub enum ConfigError {
+    NoSdCard,
+    SdError(embedded_sdmmc::Error<embedded_sdmmc::SdCardError>),
+    ParseError,
+    IoError,
+}
+
+impl From<embedded_sdmmc::Error<embedded_sdmmc::SdCardError>> for ConfigError {
+    fn from(err: embedded_sdmmc::Error<embedded_sdmmc::SdCardError>) -> Self {
+        Self::SdError(err)
+    }
+}
+
+impl Configuration {
+    /// Lädt die Konfiguration von der SD-Karte
+    async fn load_from_sd(&mut self) -> Result<(), ConfigError> {
+        let mut storage = STORAGE.get().lock().await;
+        let Some(mgr) = storage.vol_mgr() else {
+            return Err(ConfigError::NoSdCard);
+        };
+
+        let mut vol = mgr.open_volume(VolumeIdx(0))?;
+        let mut root_dir = vol.open_root_dir()?;
+
+        // Öffne Datei und lese sie komplett, bevor wir root_dir schließen
+        let buffer_result: Result<Vec<u8>, ConfigError> = {
+            match root_dir.open_file_in_dir(CONFIG_FILENAME, embedded_sdmmc::Mode::ReadOnly) {
+                Ok(mut file) => {
+                    let mut buffer = Vec::new();
+
+                    // Lese die Datei in Chunks
+                    loop {
+                        let mut chunk = [0u8; 512];
+                        match file.read(&mut chunk) {
+                            Ok(0) => break, // EOF
+                            Ok(n) => buffer.extend_from_slice(&chunk[..n]),
+                            Err(e) => {
+                                file.close()?;
+                                return Err(e.into());
+                            }
+                        }
+                    }
+
+                    file.close()?;
+                    Ok(buffer)
+                }
+                Err(embedded_sdmmc::Error::NotFound) => {
+                    // Datei existiert noch nicht, ist ok
+                    Ok(Vec::new())
+                }
+                Err(e) => Err(e.into()),
+            }
+        };
+
+        // Jetzt können wir root_dir sicher schließen
+        root_dir.close()?;
+
+        // Verarbeite das Ergebnis
+        match buffer_result {
+            Ok(buffer) => {
+                if buffer.is_empty() {
+                    self.cache.clear();
+                    self.dirty = false;
+                    self.loaded = true;
+                    return Ok(());
+                }
+
+                // Parse die Konfigurationsdatei (Format: KEY=VALUE pro Zeile)
+                self.cache.clear();
+                let content = String::from_utf8_lossy(&buffer);
+                for line in content.lines() {
+                    if let Some((key, value)) = line.split_once('=') {
+                        if let (Ok(k), Ok(v)) = (key.trim().try_into(), value.trim().try_into()) {
+                            let _ = self.cache.insert(k, v);
+                        }
+                    }
+                }
+
+                self.dirty = false;
+                self.loaded = true;
+                Ok(())
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Speichert die Konfiguration auf der SD-Karte
+    async fn save_to_sd(&mut self) -> Result<(), ConfigError> {
+        if !self.dirty {
+            return Ok(());
+        }
+
+        let mut storage = STORAGE.get().lock().await;
+        let Some(mgr) = storage.vol_mgr() else {
+            return Err(ConfigError::NoSdCard);
+        };
+
+        let mut vol = mgr.open_volume(VolumeIdx(0))?;
+        let mut root_dir = vol.open_root_dir()?;
+
+        // Erstelle den Dateiinhalt
+        let mut content = String::new();
+        for (key, value) in &self.cache {
+            content.push_str(key.as_str());
+            content.push('=');
+            content.push_str(value.as_str());
+            content.push('\n');
+        }
+
+        let data = content.as_bytes();
+
+        // Lösche alte Datei falls vorhanden
+        let _ = root_dir.delete_file_in_dir(CONFIG_FILENAME);
+
+        // Öffne, schreibe und schließe die Datei, bevor wir root_dir schließen
+        let write_result: Result<(), ConfigError> = {
+            match root_dir.open_file_in_dir(
+                CONFIG_FILENAME,
+                embedded_sdmmc::Mode::ReadWriteCreateOrTruncate,
+            ) {
+                Ok(mut file) => {
+                    // Schreibe die Daten
+                    let result = match file.write(data) {
+                        Ok(_) => Ok(()),
+                        Err(e) => Err(e.into()),
+                    };
+                    file.close()?;
+                    result
+                }
+                Err(e) => Err(e.into()),
+            }
+        };
+
+        // Jetzt können wir root_dir sicher schließen
+        root_dir.close()?;
+
+        // Wenn erfolgreich, setze dirty auf false
+        if write_result.is_ok() {
+            self.dirty = false;
+        }
+
+        write_result
+    }
+
+    pub async fn fetch(&mut self, key: &str) -> Result<Option<StrValue>, ConfigError> {
+        // Lade erst die Konfiguration, falls noch nicht geladen
+        if !self.loaded {
+            let _ = self.load_from_sd().await;
+        }
+
+        let key: StrKey = key.try_into().map_err(|_| ConfigError::ParseError)?;
+        Ok(self.cache.get(&key).cloned())
+    }
+
+    pub async fn remove(&mut self, key: &str) -> Result<(), ConfigError> {
+        // Lade erst die Konfiguration, falls noch nicht geladen
+        if !self.loaded {
+            let _ = self.load_from_sd().await;
+        }
+
+        let key: StrKey = key.try_into().map_err(|_| ConfigError::ParseError)?;
+        if self.cache.remove(&key).is_some() {
+            self.dirty = true;
+            self.save_to_sd().await?;
+        }
+        Ok(())
+    }
+
+    pub async fn store(&mut self, key: &str, value: StrValue) -> Result<(), ConfigError> {
+        // Lade erst die Konfiguration, falls noch nicht geladen
+        if !self.loaded {
+            let _ = self.load_from_sd().await;
+        }
+
+        let key: StrKey = key.try_into().map_err(|_| ConfigError::ParseError)?;
+        self.cache.insert(key, value).ok();
+        self.dirty = true;
+        self.save_to_sd().await?;
+        Ok(())
+    }
+
+    pub async fn format(&mut self) -> Result<(), ConfigError> {
+        self.cache.clear();
+        self.dirty = true;
+        self.loaded = true; // Nach format ist die Config geladen (wenn auch leer)
+        self.save_to_sd().await
+    }
+
+    pub async fn get_all(&mut self) -> Result<FnvIndexMap<StrKey, StrValue, 32>, ConfigError> {
+        // Lade erst die Konfiguration, falls noch nicht geladen
+        if !self.loaded {
+            let _ = self.load_from_sd().await;
+        }
+
+        Ok(self.cache.clone())
+    }
+}
+
+pub async fn config_command(args: &[&str]) {
+    match args {
+        ["config", "format"] => {
+            let mut config = CONFIG.get().lock().await;
+            let result = config.format().await;
+            print!("{result:?}");
+        }
+        ["config", "list"] => {
+            let mut config = CONFIG.get().lock().await;
+            match config.get_all().await {
+                Ok(map) => {
+                    for (k, v) in &map {
+                        print!("{k}={v}\r\n");
+                    }
+                }
+                Err(err) => {
+                    print!("{err:?}\r\n");
+                }
+            }
+        }
+        ["config", "get", key] => {
+            let mut config = CONFIG.get().lock().await;
+            let value = config.fetch(key).await;
+            print!("{value:?}\r\n");
+        }
+        ["config", "rm", key] => {
+            let mut config = CONFIG.get().lock().await;
+            let result = config.remove(key).await;
+            print!("{result:?}\r\n");
+        }
+        ["config", "set", key, value] => {
+            let value: StrValue = match (*value).try_into() {
+                Ok(v) => v,
+                Err(err) => {
+                    print!("value `{value}`: {err:?}\r\n");
+                    return;
+                }
+            };
+            let mut config = CONFIG.get().lock().await;
+            match config.store(key, value).await {
+                Ok(()) => {
+                    print!("OK\r\n");
+                }
+                Err(err) => {
+                    print!("{err:?}\r\n");
+                }
+            }
+        }
+        _ => {
+            print!("invalid arguments\r\n");
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -140,6 +140,9 @@ fn get_max_usable_stack() -> usize {
 
 #[embassy_executor::main]
 async fn main(spawner: Spawner) {
+    unsafe {
+        cortex_m::interrupt::enable();
+    }
     let p = embassy_rp::init(Default::default());
     crate::heap::init_heap();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,9 @@
 #![no_std]
 #![no_main]
 
-use crate::config::{CONFIG, Flash};
+use crate::config::CONFIG;
+#[cfg(not(feature = "configsdcard"))]
+use crate::config::Flash;
 use crate::heap::{HEAP, init_qmi_psram_heap};
 use crate::psram::{init_psram, init_psram_qmi};
 use crate::screen::SCREEN;
@@ -63,7 +65,14 @@ type PicoCalcDisplay<'a> = mipidsi::Display<
     Output<'a>,
 >;
 
+#[cfg(not(feature = "configsdcard"))]
+#[path = "config.rs"]
 mod config;
+
+#[cfg(feature = "configsdcard")]
+#[path = "config_sdcard.rs"]
+mod config;
+
 mod fixed_str;
 mod heap;
 mod keyboard;
@@ -239,7 +248,9 @@ async fn main(spawner: Spawner) {
     spawner.must_spawn(crate::screen::screen_painter(display));
     spawner.must_spawn(crate::keyboard::keyboard_reader(i2c_bus));
 
+    #[cfg(not(feature = "configsdcard"))]
     let flash = Flash::new(p.FLASH, p.DMA_CH3);
+    #[cfg(not(feature = "configsdcard"))]
     CONFIG.get().lock().await.assign_flash(flash);
 
     let psram = init_psram(

--- a/src/net.rs
+++ b/src/net.rs
@@ -257,9 +257,10 @@ async fn ssh_session_task(host: String, command: Option<String>) {
     match dns_client.query(&host, DnsQueryType::A).await {
         Ok(addrs) => {
             log::info!("{host} -> {addrs:?}");
-            let mut socket_tx_buf = [0u8; 8192];
-            let mut socket_rx_buf = [0u8; 8192];
-            let mut tcp_socket = TcpSocket::new(stack, &mut socket_tx_buf, &mut socket_rx_buf);
+            let mut socket_tx_buf = Box::new([0u8; 8192]);
+            let mut socket_rx_buf = Box::new([0u8; 8192]);
+            let mut tcp_socket =
+                TcpSocket::new(stack, &mut socket_tx_buf[..], &mut socket_rx_buf[..]);
 
             match tcp_socket
                 .connect(IpEndpoint {
@@ -279,9 +280,10 @@ async fn ssh_session_task(host: String, command: Option<String>) {
 
                     print!("Connected to {host} {}:22\r\n", addrs[0]);
                     let (mut read, mut write) = tcp_socket.split();
-                    let mut ssh_tx_buf = [0u8; 8192];
-                    let mut ssh_rx_buf = [0u8; 8192];
-                    let ssh_client = match SSHClient::new(&mut ssh_tx_buf, &mut ssh_rx_buf) {
+                    let mut ssh_tx_buf = Box::new([0u8; 8192]);
+                    let mut ssh_rx_buf = Box::new([0u8; 8192]);
+                    let ssh_client = match SSHClient::new(&mut ssh_tx_buf[..], &mut ssh_rx_buf[..])
+                    {
                         Ok(client) => client,
                         Err(err) => {
                             print!("SSHClient::new: {err:?}\r\n");

--- a/src/process.rs
+++ b/src/process.rs
@@ -116,6 +116,10 @@ impl LocalShell {
     }
 
     async fn dispatch_command(&self, command: &str) {
+        if command.trim().is_empty() {
+            return;
+        }
+
         let argv: Vec<&str> = command.split(' ').collect();
         let arg0 = argv[0];
         match arg0 {

--- a/src/process.rs
+++ b/src/process.rs
@@ -115,6 +115,33 @@ impl LocalShell {
         })
     }
 
+    async fn help_command(&self) {
+        print!(
+            "\u{1b}[1mbat\u{1b}[0m\r\n\
+\u{1b}[2m  \u{1b}[0mShow battery charging status percentage\r\n\
+\u{1b}[1mbl\u{1b}[0m [kbd|lcd] PCT\r\n\
+\u{1b}[2m  \u{1b}[0mShow or set keyboard/LCD backlight\r\n\
+\u{1b}[1mbootsel\u{1b}[0m\r\n\
+\u{1b}[2m  \u{1b}[0mReboot into bootsel mode\r\n\
+\u{1b}[1mcls\u{1b}[0m\r\n\
+\u{1b}[2m  \u{1b}[0mClears the screen\r\n\
+\u{1b}[1mconfig\u{1b}[0m format|list|get KEY|rm KEY|set KEY VALUE\r\n\
+\u{1b}[2m  \u{1b}[0mOperates on the configuration parameters\r\n\
+\u{1b}[1mfree\u{1b}[0m\r\n\
+\u{1b}[2m  \u{1b}[0mShows memory usage information\r\n\
+\u{1b}[1mhelp\u{1b}[0m\r\n\
+\u{1b}[2m  \u{1b}[0mDisplays this help text\r\n\
+\u{1b}[1mls\u{1b}[0m [PATH]\r\n\
+\u{1b}[2m  \u{1b}[0mShows contents of a FAT SD card\r\n\
+\u{1b}[1mreboot\u{1b}[0m\r\n\
+\u{1b}[2m  \u{1b}[0mReboot the device\r\n\
+\u{1b}[1mssh\u{1b}[0m HOST|HOST COMMAND\r\n\
+\u{1b}[2m  \u{1b}[0mConnect to host and start a shell or cmd\r\n\
+\u{1b}[1mtime\u{1b}[0m\r\n\
+\u{1b}[2m  \u{1b}[0mShow the time\r\n"
+        );
+    }
+
     async fn dispatch_command(&self, command: &str) {
         if command.trim().is_empty() {
             return;
@@ -129,6 +156,7 @@ impl LocalShell {
             "cls" => crate::screen::cls_command(&argv).await,
             "config" => crate::config::config_command(&argv).await,
             "free" => crate::heap::free_command(&argv).await,
+            "help" => self.help_command().await,
             "ls" => ls_command(&argv).await,
             "reboot" => crate::keyboard::reboot(),
             "ssh" => crate::net::ssh_command(&argv).await,


### PR DESCRIPTION
Title says it all:
- Changes that allows _UF2 loader_ compatibility, which includes moving configuration from internal flash to SD card
- New **help** command, showing all the available commands and their parameters
- Pressing enter no longer shows _Unknown command_ error